### PR TITLE
Remove extraneous CRLF

### DIFF
--- a/spec/resp_spec.cr
+++ b/spec/resp_spec.cr
@@ -7,7 +7,7 @@ describe "Resp" do
   end
 
   it "should encode expressions as RESP" do
-    assert_equal "*1\r\n$3\r\nFOO\r\n\r\n", Resp.encode(["FOO"])
+    assert_equal "*1\r\n$3\r\nFOO\r\n", Resp.encode(["FOO"])
   end
 
   it "should accept host and port" do

--- a/src/resp.cr
+++ b/src/resp.cr
@@ -38,8 +38,6 @@ class Resp
         str = arg.to_s
         res << sprintf("$%d\r\n%s\r\n", str.bytesize, str)
       end
-
-      res << "\r\n"
     end
   end
 


### PR DESCRIPTION
Tests continue to pass.

See the RESP arrays section of [the specification](https://redis.io/topics/protocol) or [a Go implementation](https://github.com/teambition/respgo/blob/master/respgo.go#L65) for examples without the trailing CRLF.